### PR TITLE
Installed HAPI Server locally and replaced the FHIRBASE URL 

### DIFF
--- a/fhirServer.js
+++ b/fhirServer.js
@@ -2,7 +2,8 @@ const path = require('path');
 const express = require('express');
 const bodyParser = require('body-parser');
 const axios = require('axios');
-const FHIR_BASE_URL = 'http://hapi.fhir.org/baseR4'; // or another FHIR server you're using
+//const FHIR_BASE_URL = 'http://hapi.fhir.org/baseR4'; // or another FHIR server you're using
+const FHIR_BASE_URL = 'http://localhost:8080/fhir';
 
 // import your existing fhirClient functions
 const {


### PR DESCRIPTION
Replaced the global server URL const FHIR_BASE_URL = 'http://hapi.fhir.org/baseR4'; with the local Hapi server
const FHIR_BASE_URL = 'http://localhost:8080/fhir';